### PR TITLE
docs: add comprehensive Swagger/OpenAPI documentation to Friends module

### DIFF
--- a/src/friends/dto/friend.dto.ts
+++ b/src/friends/dto/friend.dto.ts
@@ -1,54 +1,180 @@
 import { IsString, IsEnum } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Decimal } from '@prisma/client/runtime/library';
 
+/**
+ * Enum representing the different states of a friendship
+ */
 export enum FriendStatus {
+  /** Friend request is pending acceptance */
   PENDING = 'pending',
+  /** Friend request has been accepted */
   ACCEPTED = 'accepted',
+  /** Friend request has been rejected */
   REJECTED = 'rejected',
+  /** User has been blocked */
   BLOCKED = 'blocked',
 }
 
+/**
+ * DTO for adding a new friend
+ */
 export class AddFriendDto {
+  @ApiProperty({
+    description: 'The ID of the user to add as a friend',
+    example: 'user_2NNEqL2vHPEFSZGWHZxf3l1c5Oa',
+  })
   @IsString()
   friendId: string;
 }
 
+/**
+ * DTO for updating a friend request status
+ */
 export class UpdateFriendRequestDto {
+  @ApiProperty({
+    description: 'The new status for the friend request',
+    enum: FriendStatus,
+    example: FriendStatus.ACCEPTED,
+  })
   @IsEnum(FriendStatus)
   status: FriendStatus;
 }
 
-export class FriendResponseDto {
+/**
+ * User information included in friendship responses
+ */
+class UserInfo {
+  @ApiProperty({
+    description: 'User ID',
+    example: 'user_2NNEqL2vHPEFSZGWHZxf3l1c5Oa',
+  })
   id: string;
-  user_id: string;
-  friend_id: string;
-  status: FriendStatus;
-  created_at: Date;
-  updated_at: Date;
-  friend?: {
-    id: string;
-    fullName: string;
-    nickname?: string | null;
-    avatarUrl?: string | null;
-    rating?: Decimal | null;
-  };
-  user?: {
-    id: string;
-    fullName: string;
-    nickname?: string | null;
-    avatarUrl?: string | null;
-    rating?: Decimal | null;
-  };
+
+  @ApiProperty({
+    description: 'Full name of the user',
+    example: 'John Doe',
+  })
+  fullName: string;
+
+  @ApiPropertyOptional({
+    description: 'User nickname',
+    example: 'johndoe',
+    nullable: true,
+  })
+  nickname?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'User avatar URL',
+    example: 'https://example.com/avatar.jpg',
+    nullable: true,
+  })
+  avatarUrl?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'User rating (1-5 stars)',
+    example: 4.5,
+    nullable: true,
+  })
+  rating?: Decimal | null;
 }
 
+/**
+ * DTO representing a friendship relationship
+ */
+export class FriendResponseDto {
+  @ApiProperty({
+    description: 'Unique friendship ID',
+    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'ID of the user who initiated the friend request',
+    example: 'user_2NNEqL2vHPEFSZGWHZxf3l1c5Oa',
+  })
+  user_id: string;
+
+  @ApiProperty({
+    description: 'ID of the user who received the friend request',
+    example: 'user_2NNEqL2vHPEFSZGWHZxf3l1c5Ob',
+  })
+  friend_id: string;
+
+  @ApiProperty({
+    description: 'Current status of the friendship',
+    enum: FriendStatus,
+    example: FriendStatus.ACCEPTED,
+  })
+  status: FriendStatus;
+
+  @ApiProperty({
+    description: 'Date and time when the friendship was created',
+    example: '2025-07-30T10:30:00Z',
+  })
+  created_at: Date;
+
+  @ApiProperty({
+    description: 'Date and time when the friendship was last updated',
+    example: '2025-07-30T11:15:00Z',
+  })
+  updated_at: Date;
+
+  @ApiPropertyOptional({
+    description: 'Information about the friend (when user is the initiator)',
+    type: UserInfo,
+  })
+  friend?: UserInfo;
+
+  @ApiPropertyOptional({
+    description: 'Information about the user (when user is the recipient)',
+    type: UserInfo,
+  })
+  user?: UserInfo;
+}
+
+/**
+ * DTO representing a list of friends
+ */
 export class FriendListResponseDto {
+  @ApiProperty({
+    description: 'Array of friends',
+    type: [FriendResponseDto],
+  })
   friends: FriendResponseDto[];
+
+  @ApiProperty({
+    description: 'Total number of friends',
+    example: 15,
+  })
   total: number;
 }
 
+/**
+ * DTO representing pending friend requests (sent and received)
+ */
 export class PendingRequestsResponseDto {
+  @ApiProperty({
+    description: 'Friend requests sent by the current user',
+    type: [FriendResponseDto],
+  })
   sentRequests: FriendResponseDto[];
+
+  @ApiProperty({
+    description: 'Friend requests received by the current user',
+    type: [FriendResponseDto],
+  })
   receivedRequests: FriendResponseDto[];
+
+  @ApiProperty({
+    description: 'Total number of sent requests',
+    example: 3,
+  })
   totalSent: number;
+
+  @ApiProperty({
+    description: 'Total number of received requests',
+    example: 2,
+  })
   totalReceived: number;
 }

--- a/src/friends/friends.controller.ts
+++ b/src/friends/friends.controller.ts
@@ -10,6 +10,14 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { FriendsService } from './friends.service';
 import { ClerkAuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../decorators/user.decorator';
@@ -21,11 +29,39 @@ import {
   PendingRequestsResponseDto,
 } from './dto/friend.dto';
 
+@ApiTags('Friends')
+@ApiBearerAuth()
 @Controller('friends')
 @UseGuards(ClerkAuthGuard)
 export class FriendsController {
   constructor(private readonly friendsService: FriendsService) {}
 
+  @ApiOperation({
+    summary: 'Send a friend request',
+    description:
+      'Send a friend request to another user. The request will be in pending status until the recipient responds.',
+  })
+  @ApiBody({
+    type: AddFriendDto,
+    description: 'Information about the user to add as a friend',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Friend request sent successfully',
+    type: FriendResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - Cannot add yourself as a friend',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'User not found',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Friendship already exists',
+  })
   @Post()
   @HttpCode(HttpStatus.CREATED)
   async addFriend(
@@ -35,6 +71,29 @@ export class FriendsController {
     return this.friendsService.addFriend(userId, addFriendDto);
   }
 
+  @ApiOperation({
+    summary: 'Respond to a friend request',
+    description:
+      'Accept, reject, or block a friend request. Only the recipient of the request can perform this action.',
+  })
+  @ApiParam({
+    name: 'requestId',
+    description: 'The ID of the friend request to update',
+    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+  })
+  @ApiBody({
+    type: UpdateFriendRequestDto,
+    description: 'New status for the friend request',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Friend request updated successfully',
+    type: FriendResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Friend request not found or insufficient permissions',
+  })
   @Patch(':requestId')
   async updateFriendRequest(
     @CurrentUser() userId: string,
@@ -48,6 +107,16 @@ export class FriendsController {
     );
   }
 
+  @ApiOperation({
+    summary: 'Get friends list',
+    description:
+      'Retrieve a list of all accepted friends for the current user.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Friends list retrieved successfully',
+    type: FriendListResponseDto,
+  })
   @Get()
   async getFriends(
     @CurrentUser() userId: string,
@@ -55,6 +124,16 @@ export class FriendsController {
     return this.friendsService.getFriends(userId);
   }
 
+  @ApiOperation({
+    summary: 'Get pending friend requests',
+    description:
+      'Retrieve all pending friend requests - both sent by the user and received by the user.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Pending requests retrieved successfully',
+    type: PendingRequestsResponseDto,
+  })
   @Get('requests')
   async getPendingRequests(
     @CurrentUser() userId: string,
@@ -62,6 +141,24 @@ export class FriendsController {
     return this.friendsService.getPendingRequests(userId);
   }
 
+  @ApiOperation({
+    summary: 'Remove a friendship',
+    description:
+      'Remove an existing friendship. Both users involved in the friendship can perform this action.',
+  })
+  @ApiParam({
+    name: 'friendshipId',
+    description: 'The ID of the friendship to remove',
+    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'Friendship removed successfully',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Friendship not found or insufficient permissions',
+  })
   @Delete(':friendshipId')
   @HttpCode(HttpStatus.NO_CONTENT)
   async removeFriend(


### PR DESCRIPTION
- Add detailed API documentation to FriendsController with @ApiOperation, @ApiResponse, @ApiParam decorators
- Document all endpoints with clear descriptions, examples, and response schemas
- Add comprehensive documentation to Friend DTOs with @ApiProperty decorators
- Document FriendStatus enum with detailed descriptions for each state
- Add UserInfo class for better API schema representation
- Include proper error response documentation (400, 404, 409 status codes)
- Add @ApiTags and @ApiBearerAuth for better API organization
- Provide clear examples for request/response payloads

Features documented:
- POST /friends - Send friend request
- PATCH /friends/:requestId - Respond to friend request
- GET /friends - Get friends list
- GET /friends/requests - Get pending requests
- DELETE /friends/:friendshipId - Remove friendship