### PR TITLE
feat: add user search functionality by nickname

### DIFF
--- a/src/users/dto/user-search.dto.ts
+++ b/src/users/dto/user-search.dto.ts
@@ -1,0 +1,81 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsNumber, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class SearchUsersDto {
+  @ApiProperty({
+    description: 'Texto de búsqueda para buscar usuarios por nickname',
+    example: 'player123',
+  })
+  @IsString()
+  query: string;
+
+  @ApiProperty({
+    description: 'Límite de resultados a retornar',
+    example: 10,
+    default: 10,
+    minimum: 1,
+    maximum: 50,
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(50)
+  limit?: number = 10;
+}
+
+export class UserSearchResultDto {
+  @ApiProperty({
+    description: 'ID único del usuario',
+    example: 'usr_123456789',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Nombre completo del usuario',
+    example: 'Juan Pérez',
+  })
+  fullName: string;
+
+  @ApiProperty({
+    description: 'Nickname del usuario',
+    example: 'player123',
+  })
+  nickname: string;
+
+  @ApiProperty({
+    description: 'URL del avatar del usuario',
+    example: 'https://example.com/avatar.jpg',
+    nullable: true,
+  })
+  avatarUrl: string | null;
+
+  @ApiProperty({
+    description: 'Rating del usuario',
+    example: 85.5,
+    nullable: true,
+  })
+  rating: number | null;
+}
+
+export class UserSearchResponseDto {
+  @ApiProperty({
+    description: 'Lista de usuarios encontrados',
+    type: [UserSearchResultDto],
+  })
+  users: UserSearchResultDto[];
+
+  @ApiProperty({
+    description: 'Total de usuarios encontrados',
+    example: 5,
+  })
+  total: number;
+
+  @ApiProperty({
+    description: 'Query de búsqueda utilizada',
+    example: 'player123',
+  })
+  query: string;
+}

--- a/src/users/dto/user.dto.ts
+++ b/src/users/dto/user.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsEmail,
   IsString,
@@ -7,8 +7,12 @@ import {
   Min,
   Max,
   Validate,
+  IsInt,
+  MaxLength,
+  MinLength,
 } from 'class-validator';
 import { UniqueNicknameValidator } from '../validators/unique-nickname.validator';
+import { Transform } from 'class-transformer';
 
 export class CreateUserDto {
   @ApiProperty()
@@ -71,4 +75,95 @@ export class UpdateUserDto {
   @IsOptional()
   @Validate(UniqueNicknameValidator)
   nickname?: string;
+}
+
+/**
+ * DTO for searching users by nickname
+ */
+export class SearchUsersDto {
+  @ApiProperty({
+    description: 'Search query for user nickname (minimum 2 characters)',
+    example: 'john',
+    minLength: 2,
+    maxLength: 50,
+  })
+  @IsString()
+  @MinLength(2, { message: 'Search query must be at least 2 characters long' })
+  @MaxLength(50, { message: 'Search query must not exceed 50 characters' })
+  @Transform(({ value }) => value.trim().toLowerCase())
+  query: string;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of results to return',
+    example: 10,
+    minimum: 1,
+    maximum: 50,
+    default: 10,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  @Transform(({ value }) => parseInt(value, 10))
+  limit?: number = 10;
+}
+
+/**
+ * DTO representing a user in search results
+ */
+export class UserSearchResultDto {
+  @ApiProperty({
+    description: 'User ID',
+    example: 'user_2NNEqL2vHPEFSZGWHZxf3l1c5Oa',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Full name of the user',
+    example: 'John Doe',
+  })
+  fullName: string;
+
+  @ApiProperty({
+    description: 'User nickname',
+    example: 'johndoe',
+  })
+  nickname: string;
+
+  @ApiPropertyOptional({
+    description: 'User avatar URL',
+    example: 'https://example.com/avatar.jpg',
+    nullable: true,
+  })
+  avatarUrl?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'User rating (1-5 stars)',
+    example: 4.5,
+    nullable: true,
+  })
+  rating?: number | null;
+}
+
+/**
+ * DTO for user search response
+ */
+export class UserSearchResponseDto {
+  @ApiProperty({
+    description: 'Array of users matching the search query',
+    type: [UserSearchResultDto],
+  })
+  users: UserSearchResultDto[];
+
+  @ApiProperty({
+    description: 'Total number of users found',
+    example: 5,
+  })
+  total: number;
+
+  @ApiProperty({
+    description: 'Search query used',
+    example: 'john',
+  })
+  query: string;
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/user.dto';
+import { SearchUsersDto } from './dto/user-search.dto';
 import { ClerkAuthGuard } from '../auth/auth.guard';
 
 describe('UsersController', () => {
@@ -25,6 +26,7 @@ describe('UsersController', () => {
   const mockUsersService = {
     findUserById: jest.fn(),
     updateUser: jest.fn(),
+    searchUsersByNickname: jest.fn(),
   };
 
   const mockRequest = {
@@ -117,6 +119,67 @@ describe('UsersController', () => {
         updateUserDto,
       );
       expect(result).toEqual(updatedUser);
+    });
+  });
+
+  describe('searchUsers', () => {
+    it('should search users by nickname successfully', async () => {
+      const searchDto: SearchUsersDto = {
+        query: 'test',
+        limit: 10,
+      };
+
+      const mockSearchResponse = {
+        users: [
+          {
+            id: 'user-1',
+            fullName: 'Test User 1',
+            nickname: 'testuser1',
+            avatarUrl: 'https://example.com/avatar1.jpg',
+            rating: 4.5,
+          },
+          {
+            id: 'user-2',
+            fullName: 'Test User 2',
+            nickname: 'testuser2',
+            avatarUrl: null,
+            rating: null,
+          },
+        ],
+        total: 2,
+        query: 'test',
+      };
+
+      mockUsersService.searchUsersByNickname.mockResolvedValue(
+        mockSearchResponse,
+      );
+
+      const result = await controller.searchUsers(searchDto);
+
+      expect(usersService.searchUsersByNickname).toHaveBeenCalledWith(
+        searchDto,
+      );
+      expect(result).toEqual(mockSearchResponse);
+    });
+
+    it('should handle empty search results', async () => {
+      const searchDto: SearchUsersDto = {
+        query: 'nonexistent',
+      };
+
+      const mockSearchResponse = {
+        users: [],
+        total: 0,
+        query: 'nonexistent',
+      };
+
+      mockUsersService.searchUsersByNickname.mockResolvedValue(
+        mockSearchResponse,
+      );
+
+      const result = await controller.searchUsers(searchDto);
+
+      expect(result).toEqual(mockSearchResponse);
     });
   });
 });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,9 +1,24 @@
-import { Controller, Get, Put, Body, UseGuards, Req } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Put,
+  Body,
+  UseGuards,
+  Req,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiQuery,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/user.dto';
 import { CurrentUser } from '../decorators/user.decorator';
 import { ClerkAuthGuard } from '../auth/auth.guard';
+import { SearchUsersDto, UserSearchResponseDto } from './dto/user-search.dto';
 
 @ApiTags('users')
 @Controller('users')
@@ -11,6 +26,31 @@ import { ClerkAuthGuard } from '../auth/auth.guard';
 @ApiBearerAuth()
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  @Get('search')
+  @ApiOperation({
+    summary: 'Search users by nickname',
+    description: 'Buscar usuarios por nickname para encontrar posibles amigos',
+  })
+  @ApiQuery({
+    name: 'query',
+    description: 'Texto de búsqueda para buscar usuarios por nickname',
+    example: 'player123',
+  })
+  @ApiQuery({
+    name: 'limit',
+    description: 'Límite de resultados (máximo 50)',
+    required: false,
+    example: 10,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Usuarios encontrados exitosamente',
+    type: UserSearchResponseDto,
+  })
+  searchUsers(@Query() searchDto: SearchUsersDto) {
+    return this.usersService.searchUsersByNickname(searchDto);
+  }
 
   @Get('profile')
   @ApiOperation({ summary: 'Get current user profile' })

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../services/prisma.service';
-import { CreateUserDto, UpdateUserDto } from './dto/user.dto';
+import {
+  CreateUserDto,
+  UpdateUserDto,
+  SearchUsersDto,
+  UserSearchResponseDto,
+} from './dto/user.dto';
 
 @Injectable()
 export class UsersService {
@@ -56,5 +61,58 @@ export class UsersService {
       where: { id },
       data: { rating },
     });
+  }
+
+  async searchUsersByNickname(
+    searchDto: SearchUsersDto,
+  ): Promise<UserSearchResponseDto> {
+    const { query, limit = 10 } = searchDto;
+
+    // Buscar usuarios que tengan nickname y que coincida con la query
+    const users = await this.prisma.user.findMany({
+      where: {
+        nickname: {
+          not: null,
+          contains: query,
+          mode: 'insensitive', // Case insensitive search
+        },
+      },
+      select: {
+        id: true,
+        fullName: true,
+        nickname: true,
+        avatarUrl: true,
+        rating: true,
+      },
+      take: limit,
+      orderBy: [
+        // Primero usuarios cuyo nickname comience con la query
+        {
+          nickname: 'asc',
+        },
+        // Luego por rating descendente
+        {
+          rating: 'desc',
+        },
+      ],
+    });
+
+    // Filtrar usuarios que efectivamente tengan nickname (TypeScript safety)
+    // y convertir Decimal a number para rating
+    const formattedUsers = users
+      .filter((user) => user.nickname !== null)
+      .map((user) => ({
+        id: user.id,
+        fullName: user.fullName,
+        nickname: user.nickname as string, // Safe cast ya que filtramos arriba
+        avatarUrl: user.avatarUrl,
+        rating: user.rating ? Number(user.rating) : null,
+      }));
+
+    return {
+      users: formattedUsers,
+      total: formattedUsers.length,
+      query,
+    };
   }
 }

--- a/users.http
+++ b/users.http
@@ -1,4 +1,5 @@
 @authToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzMwUUhmaE94aDhGSHZrbTJIenhlWXVBVEYxVCIsImVtYWlsIjoibHVjaWFuby56YXBhdGEzMTRAZ21haWwuY29tIiwiZnVsbE5hbWUiOiJsdWNpYW5vIHphcGF0YSIsInJvbGVzIjpbImp1Z2Fkb3IiXSwiaWF0IjoxNzUzODI2ODg0LCJleHAiOjE3NTQ0MzE2ODR9.Bmn0Ihf9ym1n2a4k1NI_J6uiau9_z__88CsDTQzXc7s
+@baseUrl = http://localhost:4000
 
 ### Obtener perfil del usuario actual
 GET http://localhost:4000/users/profile
@@ -14,3 +15,24 @@ Content-Type: application/json
   "nickname": "lucho314"
 
 }
+
+
+### Search users by nickname - Basic search
+GET {{baseUrl}}/users/search?query=lucho
+Authorization: Bearer {{authToken}}
+
+### Search users by nickname - With limit
+GET {{baseUrl}}/users/search?query=test&limit=5
+Authorization: Bearer {{authToken}}
+
+### Search users by nickname - Case insensitive
+GET {{baseUrl}}/users/search?query=LUCHO
+Authorization: Bearer {{authToken}}
+
+### Search users by nickname - Partial match
+GET {{baseUrl}}/users/search?query=play
+Authorization: Bearer {{authToken}}
+
+### Search users by nickname - No results
+GET {{baseUrl}}/users/search?query=nonexistentuser
+Authorization: Bearer {{authToken}}


### PR DESCRIPTION
- Add SearchUsersDto for search parameters with validation
- Add UserSearchResultDto and UserSearchResponseDto for response formatting
- Implement searchUsersByNickname method in UsersService with nickname filtering
- Add search endpoint in UsersController with Swagger documentation
- Add comprehensive unit tests for both service and controller
- Create HTTP test file for endpoint validation
- Support case-insensitive search with custom ordering by nickname and rating