### PR TITLE
feat: add game player management functionality

### DIFF
--- a/friends.http
+++ b/friends.http
@@ -1,6 +1,6 @@
 ### Variables
 @baseURL = http://localhost:4000
-@authToken =eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzMwUUhmaE94aDhGSHZrbTJIenhlWXVBVEYxVCIsImVtYWlsIjoibHVjaWFuby56YXBhdGEzMTRAZ21haWwuY29tIiwiZnVsbE5hbWUiOiJsdWNpYW5vIHphcGF0YSIsInJvbGVzIjpbXSwiaWF0IjoxNzUzNzUyMTExLCJleHAiOjE3NTQzNTY5MTF9.30hIBsZn_jQq-gL6V4zd2rg8jnxTSOw85KfzEf73BJU
+@authToken ={{$dotenv TEST_AUTH_TOKEN}}
 
 ### 1. Agregar un amigo
 POST {{baseURL}}/friends

--- a/games-players.http
+++ b/games-players.http
@@ -1,0 +1,46 @@
+### Variables
+@baseUrl = http://localhost:4000
+@token = {{$dotenv TEST_AUTH_TOKEN}}
+@gameId = 669247c1-7ba8-4e73-a1cc-4b9256f19c4f
+@playerId = user_123456789
+
+### Join a game
+POST {{baseUrl}}/games/{{gameId}}/join
+Authorization: Bearer {{token}}
+
+### Leave a game
+POST {{baseUrl}}/games/{{gameId}}/leave
+Authorization: Bearer {{token}}
+
+### Get game players
+GET {{baseUrl}}/games/{{gameId}}/players
+Authorization: Bearer {{token}}
+
+### Kick a player (only organizer)
+POST {{baseUrl}}/games/{{gameId}}/kick/{{playerId}}
+Authorization: Bearer {{token}}
+
+### Create a new game (for testing)
+POST {{baseUrl}}/games
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "fieldId": "550e8400-e29b-41d4-a716-446655440001",
+  "gameType": 5,
+  "gameLevel": 1,
+  "startTime": "2025-08-01T18:00:00.000Z",
+  "endTime": "2025-08-01T20:00:00.000Z",
+  "totalSpots": 10,
+  "availableSpots": 10,
+  "pricePerPlayer": 15.00,
+  "status": "open"
+}
+
+### Get all games
+GET {{baseUrl}}/games
+Authorization: Bearer {{token}}
+
+### Get game by ID
+GET {{baseUrl}}/games/{{gameId}}
+Authorization: Bearer {{token}}

--- a/games.http
+++ b/games.http
@@ -1,4 +1,4 @@
-@authToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzMwUUhmaE94aDhGSHZrbTJIenhlWXVBVEYxVCIsImVtYWlsIjoibHVjaWFuby56YXBhdGEzMTRAZ21haWwuY29tIiwiZnVsbE5hbWUiOiJsdWNpYW5vIHphcGF0YSIsInJvbGVzIjpbXSwiaWF0IjoxNzUzNzUyMTExLCJleHAiOjE3NTQzNTY5MTF9.30hIBsZn_jQq-gL6V4zd2rg8jnxTSOw85KfzEf73BJU
+@authToken = {{$dotenv TEST_AUTH_TOKEN}}
 
 ### Insertar un nuevo game (requiere token JWT en Authorization)
 POST http://localhost:4000/games

--- a/src/games/dto/game-player.dto.ts
+++ b/src/games/dto/game-player.dto.ts
@@ -1,0 +1,93 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsIn, IsOptional } from 'class-validator';
+
+export class JoinGameDto {
+  @ApiProperty({
+    description: 'ID del juego al que el usuario se quiere unir',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsString()
+  gameId: string;
+}
+
+export class UpdatePlayerStatusDto {
+  @ApiProperty({
+    description: 'Nuevo estado del jugador en el juego',
+    enum: ['joined', 'left', 'kicked'],
+    example: 'joined',
+  })
+  @IsIn(['joined', 'left', 'kicked'])
+  status: string;
+}
+
+export class GamePlayerDto {
+  @ApiProperty({
+    description: 'ID único del registro de jugador en el juego',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'ID del juego',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  gameId: string;
+
+  @ApiProperty({
+    description: 'ID del jugador',
+    example: 'user_123456789',
+  })
+  playerId: string;
+
+  @ApiProperty({
+    description: 'Fecha y hora cuando el jugador se unió al juego',
+    example: '2025-07-30T15:30:00Z',
+  })
+  joinedAt: Date;
+
+  @ApiProperty({
+    description: 'Estado del jugador en el juego',
+    enum: ['joined', 'left', 'kicked'],
+    example: 'joined',
+  })
+  status: string;
+
+  @ApiProperty({
+    description: 'Información del jugador',
+    required: false,
+  })
+  @IsOptional()
+  player?: {
+    id: string;
+    fullName: string;
+    nickname?: string | null;
+    avatarUrl?: string | null;
+    rating?: number | null;
+  };
+}
+
+export class GamePlayersResponseDto {
+  @ApiProperty({
+    description: 'Lista de jugadores en el juego',
+    type: [GamePlayerDto],
+  })
+  players: GamePlayerDto[];
+
+  @ApiProperty({
+    description: 'Total de jugadores en el juego',
+    example: 8,
+  })
+  totalPlayers: number;
+
+  @ApiProperty({
+    description: 'Espacios disponibles restantes',
+    example: 2,
+  })
+  availableSpots: number;
+
+  @ApiProperty({
+    description: 'Total de espacios en el juego',
+    example: 10,
+  })
+  totalSpots: number;
+}

--- a/src/games/games.service.spec.ts
+++ b/src/games/games.service.spec.ts
@@ -1,9 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
 import { GamesService } from './games.service';
 import { PrismaService } from '../services/prisma.service';
 
 describe('GamesService', () => {
   let gamesService: GamesService;
+
+  const mockPrismaService = {
+    game: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    gamePlayer: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn(),
+    },
+    $queryRawUnsafe: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -11,39 +31,16 @@ describe('GamesService', () => {
         GamesService,
         {
           provide: PrismaService,
-          useValue: {
-            game: {
-              findMany: jest.fn(() =>
-                Promise.resolve([
-                  { id: '1', name: 'Game 1' },
-                  { id: '2', name: 'Game 2' },
-                ]),
-              ),
-              findUnique: jest.fn(({ where: { id } }) =>
-                Promise.resolve({ id, name: `Game ${id}` }),
-              ),
-            },
-            $queryRawUnsafe: jest.fn(() =>
-              Promise.resolve([
-                {
-                  field_name: 'Field A',
-                  distance_meters: 500,
-                  game_id: '1',
-                  start_time: '2025-08-01T18:00:00.000Z',
-                  available_spots: 5,
-                  price_per_player: '100',
-                  organizer_name: 'John Doe',
-                  game_level: 1,
-                  game_type: 5,
-                },
-              ]),
-            ),
-          },
+          useValue: mockPrismaService,
         },
       ],
     }).compile();
 
     gamesService = module.get<GamesService>(GamesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('debería estar definido', () => {
@@ -52,6 +49,11 @@ describe('GamesService', () => {
 
   describe('findAll', () => {
     it('debería devolver una lista de juegos', async () => {
+      mockPrismaService.game.findMany.mockResolvedValue([
+        { id: '1', name: 'Game 1' },
+        { id: '2', name: 'Game 2' },
+      ]);
+
       const result = await gamesService.findAll();
       expect(result).toEqual([
         { id: '1', name: 'Game 1' },
@@ -63,13 +65,18 @@ describe('GamesService', () => {
   describe('findOne', () => {
     it('debería devolver un juego por ID', async () => {
       const id = '1';
+      mockPrismaService.game.findUnique.mockResolvedValue({
+        id,
+        name: `Game ${id}`,
+      });
+
       const result = await gamesService.findOne(id);
       expect(result).toEqual({ id, name: `Game ${id}` });
     });
   });
 
   describe('findNearby', () => {
-    it('debería devolver una lista de juegos cercanos agrupados por cancha', async () => {
+    it('should return nearby games grouped by field', async () => {
       const mockQueryResult = [
         {
           field_name: 'Field A',
@@ -88,8 +95,270 @@ describe('GamesService', () => {
         },
       ];
 
+      mockPrismaService.$queryRawUnsafe.mockResolvedValue([
+        {
+          field_name: 'Field A',
+          distance_meters: 500,
+          game_id: '1',
+          start_time: '2025-08-01T18:00:00.000Z',
+          available_spots: 5,
+          price_per_player: '100',
+          organizer_name: 'John Doe',
+          game_level: 1,
+          game_type: 5,
+        },
+      ]);
+
       const result = await gamesService.findNearby(40.7128, -74.006, 1000);
       expect(result).toEqual(mockQueryResult);
+    });
+  });
+
+  describe('joinGame', () => {
+    it('should successfully join a game', async () => {
+      const gameId = 'game-1';
+      const playerId = 'player-1';
+
+      const mockGame = {
+        id: gameId,
+        status: 'open',
+        availableSpots: 3,
+        gamePlayers: [],
+      };
+
+      const mockNewPlayer = {
+        id: 'gameplayer-1',
+        gameId,
+        playerId,
+        status: 'joined',
+        joinedAt: new Date(),
+        player: {
+          id: playerId,
+          fullName: 'Test Player',
+          nickname: 'testplayer',
+          avatarUrl: null,
+          rating: 4.5,
+        },
+      };
+
+      mockPrismaService.game.findUnique.mockResolvedValue(mockGame);
+      mockPrismaService.gamePlayer.findUnique.mockResolvedValue(null);
+      mockPrismaService.gamePlayer.create.mockResolvedValue(mockNewPlayer);
+      mockPrismaService.game.update.mockResolvedValue(mockGame);
+
+      const result = await gamesService.joinGame(gameId, playerId);
+
+      expect(mockPrismaService.game.findUnique).toHaveBeenCalledWith({
+        where: { id: gameId },
+        include: {
+          gamePlayers: {
+            where: { status: 'joined' },
+          },
+        },
+      });
+      expect(mockPrismaService.gamePlayer.create).toHaveBeenCalledWith({
+        data: {
+          gameId,
+          playerId,
+          status: 'joined',
+        },
+        include: {
+          player: {
+            select: {
+              id: true,
+              fullName: true,
+              nickname: true,
+              avatarUrl: true,
+              rating: true,
+            },
+          },
+        },
+      });
+      expect(result).toEqual(mockNewPlayer);
+    });
+
+    it('should throw NotFoundException if game does not exist', async () => {
+      const gameId = 'nonexistent-game';
+      const playerId = 'player-1';
+
+      mockPrismaService.game.findUnique.mockResolvedValue(null);
+
+      await expect(gamesService.joinGame(gameId, playerId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException if game is not open', async () => {
+      const gameId = 'game-1';
+      const playerId = 'player-1';
+
+      const mockGame = {
+        id: gameId,
+        status: 'closed',
+        availableSpots: 3,
+        gamePlayers: [],
+      };
+
+      mockPrismaService.game.findUnique.mockResolvedValue(mockGame);
+
+      await expect(gamesService.joinGame(gameId, playerId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException if no available spots', async () => {
+      const gameId = 'game-1';
+      const playerId = 'player-1';
+
+      const mockGame = {
+        id: gameId,
+        status: 'open',
+        availableSpots: 0,
+        gamePlayers: [],
+      };
+
+      mockPrismaService.game.findUnique.mockResolvedValue(mockGame);
+
+      await expect(gamesService.joinGame(gameId, playerId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw ConflictException if player already joined', async () => {
+      const gameId = 'game-1';
+      const playerId = 'player-1';
+
+      const mockGame = {
+        id: gameId,
+        status: 'open',
+        availableSpots: 3,
+        gamePlayers: [],
+      };
+
+      const mockExistingPlayer = {
+        id: 'gameplayer-1',
+        gameId,
+        playerId,
+        status: 'joined',
+      };
+
+      mockPrismaService.game.findUnique.mockResolvedValue(mockGame);
+      mockPrismaService.gamePlayer.findUnique.mockResolvedValue(
+        mockExistingPlayer,
+      );
+
+      await expect(gamesService.joinGame(gameId, playerId)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+  });
+
+  describe('leaveGame', () => {
+    it('should successfully leave a game', async () => {
+      const gameId = 'game-1';
+      const playerId = 'player-1';
+
+      const mockGamePlayer = {
+        id: 'gameplayer-1',
+        gameId,
+        playerId,
+        status: 'joined',
+      };
+
+      const mockUpdatedPlayer = {
+        ...mockGamePlayer,
+        status: 'left',
+        player: {
+          id: playerId,
+          fullName: 'Test Player',
+          nickname: 'testplayer',
+          avatarUrl: null,
+          rating: 4.5,
+        },
+      };
+
+      mockPrismaService.gamePlayer.findUnique.mockResolvedValue(mockGamePlayer);
+      mockPrismaService.gamePlayer.update.mockResolvedValue(mockUpdatedPlayer);
+      mockPrismaService.game.update.mockResolvedValue({});
+
+      const result = await gamesService.leaveGame(gameId, playerId);
+
+      expect(mockPrismaService.gamePlayer.update).toHaveBeenCalledWith({
+        where: { id: mockGamePlayer.id },
+        data: { status: 'left' },
+        include: {
+          player: {
+            select: {
+              id: true,
+              fullName: true,
+              nickname: true,
+              avatarUrl: true,
+              rating: true,
+            },
+          },
+        },
+      });
+      expect(result).toEqual(mockUpdatedPlayer);
+    });
+
+    it('should throw NotFoundException if player not in game', async () => {
+      const gameId = 'game-1';
+      const playerId = 'player-1';
+
+      mockPrismaService.gamePlayer.findUnique.mockResolvedValue(null);
+
+      await expect(gamesService.leaveGame(gameId, playerId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getGamePlayers', () => {
+    it('should return game players successfully', async () => {
+      const gameId = 'game-1';
+
+      const mockGame = {
+        id: gameId,
+        totalSpots: 10,
+        availableSpots: 2,
+      };
+
+      const mockPlayers = [
+        {
+          id: 'gameplayer-1',
+          gameId,
+          playerId: 'player-1',
+          status: 'joined',
+          joinedAt: new Date(),
+          player: {
+            id: 'player-1',
+            fullName: 'Player 1',
+            nickname: 'player1',
+            avatarUrl: null,
+            rating: 4.5,
+          },
+        },
+      ];
+
+      mockPrismaService.game.findUnique.mockResolvedValue(mockGame);
+      mockPrismaService.gamePlayer.findMany.mockResolvedValue(mockPlayers);
+
+      const result = await gamesService.getGamePlayers(gameId);
+
+      expect(result.players).toHaveLength(1);
+      expect(result.totalPlayers).toBe(1);
+      expect(result.availableSpots).toBe(2);
+      expect(result.totalSpots).toBe(10);
+    });
+
+    it('should throw NotFoundException if game does not exist', async () => {
+      const gameId = 'nonexistent-game';
+
+      mockPrismaService.game.findUnique.mockResolvedValue(null);
+
+      await expect(gamesService.getGamePlayers(gameId)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/games/games.service.ts
+++ b/src/games/games.service.ts
@@ -1,6 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
 import { PrismaService } from '../services/prisma.service';
 import { CreateGameDto, UpdateGameDto } from './dto/game.dto';
+import { GamePlayersResponseDto } from './dto/game-player.dto';
 
 @Injectable()
 export class GamesService {
@@ -111,5 +117,267 @@ export class GamesService {
     }, []);
 
     return groupedResults;
+  }
+
+  // Métodos para manejar jugadores en juegos
+
+  async joinGame(gameId: string, playerId: string) {
+    // Verificar que el juego existe y tiene espacios disponibles
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      include: {
+        gamePlayers: {
+          where: { status: 'joined' },
+        },
+      },
+    });
+
+    if (!game) {
+      throw new NotFoundException('Juego no encontrado');
+    }
+
+    if (game.status !== 'open') {
+      throw new BadRequestException(
+        'El juego no está abierto para nuevos jugadores',
+      );
+    }
+
+    if (game.availableSpots <= 0) {
+      throw new BadRequestException(
+        'No hay espacios disponibles en este juego',
+      );
+    }
+
+    // Verificar que el jugador no esté ya en el juego
+    const existingPlayer = await this.prisma.gamePlayer.findUnique({
+      where: {
+        gameId_playerId: {
+          gameId,
+          playerId,
+        },
+      },
+    });
+
+    if (existingPlayer) {
+      if (existingPlayer.status === 'joined') {
+        throw new ConflictException('Ya estás unido a este juego');
+      }
+      // Si ya existe pero con otro status, actualizamos a 'joined'
+      const updatedPlayer = await this.prisma.gamePlayer.update({
+        where: { id: existingPlayer.id },
+        data: { status: 'joined', joinedAt: new Date() },
+        include: {
+          player: {
+            select: {
+              id: true,
+              fullName: true,
+              nickname: true,
+              avatarUrl: true,
+              rating: true,
+            },
+          },
+        },
+      });
+
+      return updatedPlayer;
+    }
+
+    // Crear nuevo registro de jugador
+    const newPlayer = await this.prisma.gamePlayer.create({
+      data: {
+        gameId,
+        playerId,
+        status: 'joined',
+      },
+      include: {
+        player: {
+          select: {
+            id: true,
+            fullName: true,
+            nickname: true,
+            avatarUrl: true,
+            rating: true,
+          },
+        },
+      },
+    });
+
+    // Actualizar espacios disponibles
+    await this.prisma.game.update({
+      where: { id: gameId },
+      data: { availableSpots: { decrement: 1 } },
+    });
+
+    return newPlayer;
+  }
+
+  async leaveGame(gameId: string, playerId: string) {
+    // Verificar que el jugador está en el juego
+    const gamePlayer = await this.prisma.gamePlayer.findUnique({
+      where: {
+        gameId_playerId: {
+          gameId,
+          playerId,
+        },
+      },
+    });
+
+    if (!gamePlayer) {
+      throw new NotFoundException('No estás unido a este juego');
+    }
+
+    if (gamePlayer.status !== 'joined') {
+      throw new BadRequestException('No estás actualmente unido a este juego');
+    }
+
+    // Actualizar status a 'left'
+    const updatedPlayer = await this.prisma.gamePlayer.update({
+      where: { id: gamePlayer.id },
+      data: { status: 'left' },
+      include: {
+        player: {
+          select: {
+            id: true,
+            fullName: true,
+            nickname: true,
+            avatarUrl: true,
+            rating: true,
+          },
+        },
+      },
+    });
+
+    // Actualizar espacios disponibles
+    await this.prisma.game.update({
+      where: { id: gameId },
+      data: { availableSpots: { increment: 1 } },
+    });
+
+    return updatedPlayer;
+  }
+
+  async getGamePlayers(gameId: string): Promise<GamePlayersResponseDto> {
+    // Verificar que el juego existe
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      select: {
+        id: true,
+        totalSpots: true,
+        availableSpots: true,
+      },
+    });
+
+    if (!game) {
+      throw new NotFoundException('Juego no encontrado');
+    }
+
+    // Obtener todos los jugadores del juego
+    const players = await this.prisma.gamePlayer.findMany({
+      where: {
+        gameId,
+        status: 'joined', // Solo jugadores activos
+      },
+      include: {
+        player: {
+          select: {
+            id: true,
+            fullName: true,
+            nickname: true,
+            avatarUrl: true,
+            rating: true,
+          },
+        },
+      },
+      orderBy: {
+        joinedAt: 'asc',
+      },
+    });
+
+    const formattedPlayers = players.map((gamePlayer) => ({
+      id: gamePlayer.id,
+      gameId: gamePlayer.gameId,
+      playerId: gamePlayer.playerId,
+      joinedAt: gamePlayer.joinedAt,
+      status: gamePlayer.status,
+      player: {
+        id: gamePlayer.player.id,
+        fullName: gamePlayer.player.fullName,
+        nickname: gamePlayer.player.nickname,
+        avatarUrl: gamePlayer.player.avatarUrl,
+        rating: gamePlayer.player.rating
+          ? Number(gamePlayer.player.rating)
+          : null,
+      },
+    }));
+
+    return {
+      players: formattedPlayers,
+      totalPlayers: players.length,
+      availableSpots: game.availableSpots,
+      totalSpots: game.totalSpots,
+    };
+  }
+
+  async kickPlayer(gameId: string, playerId: string, organizerId: string) {
+    // Verificar que el juego existe y que el usuario es el organizador
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      select: { organizerId: true },
+    });
+
+    if (!game) {
+      throw new NotFoundException('Juego no encontrado');
+    }
+
+    if (game.organizerId !== organizerId) {
+      throw new BadRequestException(
+        'Solo el organizador puede expulsar jugadores',
+      );
+    }
+
+    // Verificar que el jugador está en el juego
+    const gamePlayer = await this.prisma.gamePlayer.findUnique({
+      where: {
+        gameId_playerId: {
+          gameId,
+          playerId,
+        },
+      },
+    });
+
+    if (!gamePlayer) {
+      throw new NotFoundException('El jugador no está en este juego');
+    }
+
+    if (gamePlayer.status !== 'joined') {
+      throw new BadRequestException(
+        'El jugador no está actualmente unido a este juego',
+      );
+    }
+
+    // Actualizar status a 'kicked'
+    const updatedPlayer = await this.prisma.gamePlayer.update({
+      where: { id: gamePlayer.id },
+      data: { status: 'kicked' },
+      include: {
+        player: {
+          select: {
+            id: true,
+            fullName: true,
+            nickname: true,
+            avatarUrl: true,
+            rating: true,
+          },
+        },
+      },
+    });
+
+    // Actualizar espacios disponibles
+    await this.prisma.game.update({
+      where: { id: gameId },
+      data: { availableSpots: { increment: 1 } },
+    });
+
+    return updatedPlayer;
   }
 }


### PR DESCRIPTION
- Add comprehensive DTOs for game player operations
- Add joinGame, leaveGame, getGamePlayers, and kickPlayer methods to GamesService
- Add REST endpoints for player management in GamesController
- Implement business logic validations (available spots, permissions, game status)
- Add automatic available spots updates when players join/leave
- Add complete Swagger documentation for all endpoints
- Add comprehensive test coverage (17 unit tests total)
- Update HTTP test files to use environment variables for tokens

Features:
- Join/leave games with validation
- View game players list
- Kick players (organizer only)
- Automatic spot management
- Security and permission checks
- Complete error handling